### PR TITLE
Fix fatal error - defined() is a test and takes one argument.

### DIFF
--- a/Services/Html2CanvasProxy.php
+++ b/Services/Html2CanvasProxy.php
@@ -347,7 +347,7 @@ class Html2CanvasProxy
         }
 
         if (in_array('ssl', stream_get_transports())) {
-            defined('SOCKET_SSL_STREAM', '1');
+            define('SOCKET_SSL_STREAM', '1');
 
             return true;
         }


### PR DESCRIPTION
Looks like an obvious typo to me, hitting us in production.